### PR TITLE
Fix rpm file location in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Getting started
 ---------------
 
 * Make sure you have both [VirtualBox](https://www.virtualbox.org) and [Vagrant](http://vagrantup.com) installed.
-* Download and copy [Oracle Database Express Edition 11g Release 2](http://www.oracle.com/technetwork/database/express-edition/downloads/index.html) to `modules/oracle/oracle-xe-11.2.0-1.0.x86_64.rpm.zip`.
+* Download and copy [Oracle Database Express Edition 11g Release 2](http://www.oracle.com/technetwork/database/express-edition/downloads/index.html) to `modules/oracle/files/oracle-xe-11.2.0-1.0.x86_64.rpm.zip`.
 * Run `vagrant up` from your checkout directory.
 * Connect to your database at `33.33.33.10:1521/xe` with credentials `sys/manager` or `system/manager`.
 


### PR DESCRIPTION
I was getting error:

```
err: /Stage[main]/Oracle::Xe/File[/tmp/oracle-xe-11.2.0-1.0.x86_64.rpm.zip]: Could not evaluate: Could not retrieve information from environment production source(s) puppet:///modules/oracle/oracle-xe-11.2.0-1.0.x86_64.rpm.zip at /tmp/vagrant-puppet/modules-0/oracle/manifests/init.pp:74
```

Then I noticed that the path in readme.md was wrong, so I fixed that:

``` diff
- modules/oracle/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
+ modules/oracle/files/oracle-xe-11.2.0-1.0.x86_64.rpm.zip
```
