### PR TITLE
Extending vagrant-oracle-xe to handle oracle user enviroment variables and profile

### DIFF
--- a/modules/oracle/files/oracle.sh
+++ b/modules/oracle/files/oracle.sh
@@ -1,0 +1,19 @@
+if [ "$USER" = "oracle" ]; then
+	#umask 022
+
+	# if running bash
+	if [ -n "$BASH_VERSION" ]; then
+	    # include .bashrc if it exists
+	    if [ -f "$HOME/.bashrc" ]; then
+	        . "$HOME/.bashrc"
+	    fi
+	fi
+
+	# set PATH so it includes user's private bin if it exists
+	if [ -d "$HOME/bin" ] ; then
+	    PATH="$HOME/bin:$PATH"
+	fi
+
+	. /u01/app/oracle/product/11.2.0/xe/bin/oracle_env.sh
+fi
+

--- a/modules/oracle/manifests/init.pp
+++ b/modules/oracle/manifests/init.pp
@@ -42,6 +42,8 @@ class oracle::server {
   file {
     "/etc/sysctl.d/60-oracle.conf":
       source => "puppet:///modules/oracle/xe-sysctl.conf";
+    "/etc/profile.d/oracle.sh":
+      source => "puppet:///modules/oracle/oracle.sh";
   }
 
   user {


### PR DESCRIPTION
Hi Stefan,

Your vagrant-oracle-xe repository is excellent, I had my ubuntu oracle-xe environment up and running in less than 45 mins (including downloading oracle-xe.zip software from Oracle!).

There is one change I would like to make around the oracle user environment variables, in my fork I have added an /etc/profile.d/oracle.sh which is deployed automatically as part of the puppet build process (init.pp).

Now when I 'su - oracle' all the environment and path variables are set and I can use standard command line tools like sqlplus and lsnrctl.

Cheers
Dave

NB I have documented what I did in more detail under : http://haildata.net/2013/04/forking-vagrant-oracle-xe-project-to-handle-oracle-environment-variables/ 
