### PR TITLE
Fixing some problems with Vagrant installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,7 @@
 Vagrant::Config.run do |config|
 
   config.vm.define :oraxe do |db1_config|
-    db1_config.vm.box = "ubuntu-1110-server-amd64"
-    db1_config.vm.box_url = "http://timhuegdon.com/vagrant-boxes/ubuntu-11.10.box"
+    db1_config.vm.box = "ubuntu/trusty64"
     db1_config.vm.host_name = "oraxe"
     db1_config.vm.forward_port 22, 41022, :adapter => 1
     db1_config.vm.network :hostonly, "33.33.33.10", :adapter => 2

--- a/modules/oracle/manifests/init.pp
+++ b/modules/oracle/manifests/init.pp
@@ -1,4 +1,5 @@
 class oracle::server {
+
   exec {
     "/usr/bin/apt-get -y update":
       alias => "aptUpdate",
@@ -83,10 +84,10 @@ class oracle::xe {
       user => root,
       creates => "/tmp/oracle-xe-11.2.0-1.0.x86_64.rpm";
     "alien xe":
-      command => "/usr/bin/alien --to-deb --scripts /tmp/Disk1/oracle-xe-11.2.0-1.0.x86_64.rpm",
-      cwd => "/tmp/Disk1",
+      command => "/usr/bin/alien --to-deb --scripts /tmp/oracle-xe-11.2.0-1.0.x86_64.rpm",
+      cwd => "/tmp",
       require => Exec["unzip xe"],
-      creates => "/tmp/Disk1/oracle-xe_11.2.0-2_amd64.deb",
+      creates => "/tmp/oracle-xe_11.2.0-2_amd64.deb",
       user => root;
     "configure xe":
       command => "/etc/init.d/oracle-xe configure responseFile=/tmp/xe.rsp >> /tmp/xe-install.log",
@@ -108,6 +109,6 @@ class oracle::xe {
       provider => "dpkg",
       ensure => latest,
       require => Exec["alien xe"],
-      source => "/tmp/Disk1/oracle-xe_11.2.0-2_amd64.deb";
+      source => "/tmp/oracle-xe_11.2.0-2_amd64.deb";
   }
 }


### PR DESCRIPTION
The repository that is using the actual Vagrantfile has some problems with the GPG key from the apt repository. I've reconfigured the box to use the last LTS from Atlas repository.
Also there was an issue with the unzip output that was not creating the Disk1 directory, so there is no need for cwd and the afterwards references to this directory.
